### PR TITLE
Dialect has header

### DIFF
--- a/source/Csv/Dialect.php
+++ b/source/Csv/Dialect.php
@@ -75,6 +75,11 @@ class Csv_Dialect
     public $lineterminator = "\r\n";
 
     /**
+     * @var boolean Does this CSV hav a header?
+     */
+    public $hasheader = false;
+
+    /**
      * @var integer Set to any of the self::QUOTE_* constants above
      * @todo QUOTE_NONNUMERIC would probably make the most sense here
      */

--- a/source/Csv/Reader.php
+++ b/source/Csv/Reader.php
@@ -186,6 +186,15 @@ class Csv_Reader extends Csv_Reader_Abstract
         rewind($this->handle);
         $this->position = 0;
         $this->loadRow(); // loads the current (first) row into memory 
+        if ($this->dialect->hasheader) {
+            // Can't call call getHeader() due to infinite loop.  So instead
+            // do the same work.
+            $current = $this->current();
+            $this->position++;
+            $this->headerRow = $current;
+            // Go to the next row.
+            $this->next();
+        }
     }
 
     /**

--- a/source/Csv/Reader.php
+++ b/source/Csv/Reader.php
@@ -108,7 +108,7 @@ class Csv_Reader extends Csv_Reader_Abstract
         ) array_walk($this->current, array($this, 'unescape'));
         // if this row is blank and dialect says to skip blank lines, load in the next one and pretend this never happened
         if ($this->dialect->skipblanklines && is_array($this->current) && count($this->current) == 1 && $this->current[0] == '') {
-            $this->skippedlines++;
+            $this->skippedLines++;
             $this->next();
         }
     }

--- a/source/Csv/Reader/Abstract.php
+++ b/source/Csv/Reader/Abstract.php
@@ -173,7 +173,7 @@ abstract class Csv_Reader_Abstract implements Iterator, Countable
      */
     public function getSkippedLines()
     {
-        return $this->skippedlines;
+        return $this->skippedLines;
     }
 
     /**

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -12,6 +12,7 @@ class ReaderTest extends PHPUnit_Framework_TestCase
         $this->files['comma-200'] = __DIR__ . '/data/comma-200.csv';
         $this->files['blank-lines-200'] = __DIR__ . '/data/blank-lines-200.csv';
         $this->files['too-short'] = __DIR__ . '/data/too-short.csv';
+        $this->files['comma-quote-minimal'] = __DIR__ . '/data/comma-quote-minimal.csv';
         $this->tempfile = sys_get_temp_dir() . '/tmp.csv';
     }
 
@@ -398,4 +399,54 @@ class ReaderTest extends PHPUnit_Framework_TestCase
         $row = $reader->getRow();
         $this->assertEquals(array('foo','ﺡ','bar'), $row);
     }
+
+    /**
+     * We should get back the path to the csv file if the csv file exists
+     */
+    public function test_Csv_Reader_HasHeader()
+    {
+        $dialect = new Csv_Dialect();
+        $dialect->hasheader = true;
+        $reader = new Csv_Reader($this->files['comma-quote-minimal'], $dialect);
+
+        // Assert count.
+        $this->assertEquals(100, $reader->count());
+
+        // Assert header contents.
+        $actual_header = $reader->getHeader();
+        $expected_header = array(
+            'name',
+            'date',
+            'email',
+            'address_1',
+            'city',
+            'state',
+            'zip',
+            'country',
+            'phone',
+            'fax',
+            'keywords',
+            'order_id',
+        );
+        $this->assertEquals($actual_header, $expected_header);
+    }
+
+
+    function data_provider_test_provider()
+    {
+        $dialect = new Csv_Dialect();
+        $dialect->hasheader = true;
+        $reader = new Csv_Reader(__DIR__ . '/data/comma-quote-minimal.csv', $dialect);
+        return $reader;
+    }
+
+
+    /**
+     * @dataProvider data_provider_test_provider
+     */
+    public function test_php_csv_utils_as_data_provider( $name, $date, $email, $address_1, 
+      $city, $state, $zip, $country, $phone, $fax, $keywords, $order_id ) {
+        $this->assertEquals( strlen($state), 2 );
+    }
+
 }


### PR DESCRIPTION
This patch allows the user to specify in the dialect that the CSV has a header.  The Reader will automatically read the header and store it.  This patch includes a few automated tests and a demo of how to use php-csv-utils as a PHPUnit data provider.
